### PR TITLE
Improve test enabling/disabling mechanism.

### DIFF
--- a/vscaide/UI/EditTestsWindow.xaml
+++ b/vscaide/UI/EditTestsWindow.xaml
@@ -1,16 +1,41 @@
 ﻿<Window x:Class="slycelote.VsCaide.UI.EditTestsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:slycelote.VsCaide.UI;assembly="
         Title="Edit tests" Height="300" Width="400" Topmost="True">
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="120"/>
+            <ColumnDefinition Width="150"/>
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <Grid HorizontalAlignment="Stretch">
-            <ListBox x:Name="lstTestCases" Margin="5,10,5,36.6" SelectionChanged="lstTestCases_SelectionChanged" />
+            <ListView x:Name="lstTestCases" Margin="5,10,5,36.6" ItemsSource="{Binding TestCases}" SelectedItem="{Binding SelectedCase}" SelectionChanged="lstTestCases_SelectionChanged" SelectionMode="Single">
+                <ListView.View>
+                    <GridView>
+                        <GridView.Columns>
+                            <GridViewColumn Width="30">
+                                <GridViewColumn.CellTemplate>
+                                    <HierarchicalDataTemplate>
+                                        <CheckBox IsChecked="{Binding IsEnabled}"/>
+                                    </HierarchicalDataTemplate>
+                                </GridViewColumn.CellTemplate>
+                                <GridViewColumn.Header>
+                                    <local:ExtendedCheckBox IsChecked="{Binding AllEnabled}" Click="OnCbClicked" InvertCheckStateOrder="True"/>
+                                </GridViewColumn.Header>
+                            </GridViewColumn>
+                            <GridViewColumn Width="100">
+                                <GridViewColumn.CellTemplate>
+                                    <HierarchicalDataTemplate>
+                                        <TextBlock Text="{Binding Name}" Margin="20,0"/>
+                                    </HierarchicalDataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                        </GridView.Columns>
+                    </GridView>
+                </ListView.View>
+            </ListView>
             <Button x:Name="btnAdd" Content="Add" HorizontalAlignment="Left" Margin="10,0,0,10" Width="41" VerticalAlignment="Bottom" Click="btnAdd_Click"/>
-            <Button x:Name="btnDelete" Content="Delete" Margin="0,0,10,10" HorizontalAlignment="Right" Width="41" Height="22" VerticalAlignment="Bottom" Click="btnDelete_Click"/>
+            <Button x:Name="btnDelete" Content="Delete" Margin="0,0,10,10" HorizontalAlignment="Right" Width="41" VerticalAlignment="Bottom" Click="btnDelete_Click"/>
         </Grid>
         <Grid Margin="0" Grid.Column="1"> 
             <Grid.RowDefinitions>
@@ -20,7 +45,6 @@
             </Grid.RowDefinitions>
             <TextBox x:Name="txtInput" Margin="5,5,5,0" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Stretch" TextChanged="txtInput_TextChanged" AcceptsReturn="True" FontFamily="Lucida Console" />
             <StackPanel Orientation="Horizontal" Grid.Row="1">
-                <CheckBox x:Name="chkSkipped" Content="Skipped" FlowDirection="RightToLeft" HorizontalAlignment="Left" Width="70" VerticalAlignment="Center" Margin="10,3,10,3" Click="chkSkipped_Click"/>
                 <CheckBox x:Name="chkOutputKnown" Content="Output known" Margin="10,0" FlowDirection="RightToLeft" VerticalAlignment="Center" HorizontalAlignment="Left" Click="chkOutputKnown_Click" />
             </StackPanel>
             <TextBox x:Name="txtOutput" Margin="5,0,5,5" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="2" TextChanged="txtOutput_TextChanged" AcceptsReturn="True" FontFamily="Lucida Console"/>


### PR DESCRIPTION
I really like to use vscaide but I find that I need to disable/enable all the tests quite frequently due to the fact that I want to debug only specific one at certain times and it could be bothersome. 

`CHelper` has 'Select All' / 'Select None' buttons to solve this. But I wanted to implement a little bit more elegant solution. And thus I added the checkboxes on the side of test list signifying is this test currently enabled (not skipped) or not and one checkbox in the header for enabling / disabling all of the tests at once.

It looks like this currently:
![image](https://user-images.githubusercontent.com/2133957/29384517-15d3749a-82dd-11e7-8721-5d59e783dd21.png)

Sadly implementation includes some workarounds for WPF quirks I encountered but overall I've tried to touch as less code as possible. I'm ready to apply any code or UI style changes you find appropriate.

What do you think?
