### PR TITLE
Update default Competitive Companion port to 10043

### DIFF
--- a/libcaide/README.md
+++ b/libcaide/README.md
@@ -42,8 +42,8 @@ sites.) Because of how the extensions work, you have to be running a local
 server that will accept requests from the browser. This is done in command line
 with `caide httpServer`. Hit Return to stop the server.
 
-Default port for Competitive Companion is 8080. (It can be changed in
-[config](#configuration)). You need to add it as an additional port in
+Default port for Competitive Companion is 10043. (It can be changed in
+[config](#configuration)). If you change it, you need to add it as an additional port in
 the settings of the browser extension.
 
 
@@ -61,7 +61,7 @@ Most settings are stored in `caide.ini` file in the project root.
   functionality). Settings for each feature are kept in the corresponding
   section of the file. Currently the only implemented feature is 'codelite'
   which enables a limited [support for Codelite IDE](#codelite).
-* `chelper_port` (default 4243) and `companion_port` (default 8080) control
+* `chelper_port` (default 4243) and `companion_port` (default 10043) control
   ports that [`caide httpServer` command](#http-server) uses for communicating
   with browser extensions. Set a port to -1 to disable the corresponding server.
 

--- a/libcaide/src/Caide/Commands/CHelperHttpServer.hs
+++ b/libcaide/src/Caide/Commands/CHelperHttpServer.hs
@@ -81,7 +81,7 @@ runServers root companionPort chelperPort = withSocketsDo $ do
 getPorts :: CaideIO (Int, Int)
 getPorts = do
     h <- readCaideConf
-    companionPort <- getProp h "core" "companion_port" `orDefault` 8080
+    companionPort <- getProp h "core" "companion_port" `orDefault` 10043
     chelperPort <- getProp h "core" "chelper_port" `orDefault` 4243
     return (companionPort, chelperPort)
 

--- a/libcaide/tests/companion.test
+++ b/libcaide/tests/companion.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 (sleep 10; echo .) | "$CAIDE" httpServer &
-curl -d @request.json -H "Content-Type: application/json" http://localhost:8080
-curl -d @request2.json -H "Content-Type: application/json" http://localhost:8080
+curl -d @request.json -H "Content-Type: application/json" http://localhost:10043
+curl -d @request2.json -H "Content-Type: application/json" http://localhost:10043
 
 compare_with after-parse {ADayOfTakahashi,BMaximumSum,GCastleDefense}/problem.ini
 compare_with after-parse {ADayOfTakahashi,GCastleDefense}/case{1,2,3}.{in,out}


### PR DESCRIPTION
Title says it all. I have added port 10043 to the default configuration of Competitive Companion in 2.8.2 ~which will go live in a few minutes~. This removes the need to add 8080 as a custom port when using Caide and Competitive Companion together.